### PR TITLE
Feature/user/signout

### DIFF
--- a/user/permissions.py
+++ b/user/permissions.py
@@ -1,0 +1,9 @@
+from rest_framework import permissions
+
+
+class SignOutAuthenticatedOnly(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.method == "PUT":
+            return bool(request.user and request.user.is_authenticated)
+        else:
+            return True

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -63,6 +63,27 @@ class UserSerializer(serializers.ModelSerializer):
         return super().validate(attrs)
 
 
+class UserSignOutSerializer(serializers.ModelSerializer):
+    """
+    회원 탈퇴를 위해 오직 password만 받는 serializer 이다.
+    create도 update도 하지 않는다.
+    오직 비밀번호 일치 여부만 validate한다.
+    """
+
+    class Meta:
+        model = User
+        fields = ("password",)
+        extra_kwargs = {
+            # write_only : 해당 필드를 쓰기 전용으로 만들어 준다.
+            "password": {"write_only": True},
+        }
+
+    def validate(self, attrs):
+        if not self.instance.check_password(attrs.get("password")):
+            raise serializers.ValidationError({"password": "password wrong."})
+        return super().validate(attrs)
+
+
 class MyTokenObtainSerializer(TokenObtainPairSerializer):
     """
     토큰 발급시 사용되는 serializer입니다.

--- a/user/views.py
+++ b/user/views.py
@@ -7,6 +7,7 @@ from user.serializers import (
     MyTokenObtainSerializer,
     UserSignOutSerializer,
 )
+from user.permissions import SignOutAuthenticatedOnly
 from rest_framework.generics import get_object_or_404
 from user.models import User
 
@@ -18,7 +19,7 @@ class UserSignUpAndOutView(APIView):
     Post(가입)와 Delete(탈퇴) 요청만 받음.
     """
 
-    # permission_classes = (IsExsistDeleteXorCreateOnly,)
+    permission_classes = (SignOutAuthenticatedOnly,)
 
     def post(self, request):
         """
@@ -38,6 +39,7 @@ class UserSignUpAndOutView(APIView):
         일치하면 해당 유저의 is_active 값을 False로 바꾼다.
         상태코드 200 : 탈퇴성공
         상태코드 400 : 비밀번호 틀림
+        상태코드 401 : 만료토큰/로그인안함
         """
         user = request.user
         user = get_object_or_404(User, id=user.id)

--- a/user/views.py
+++ b/user/views.py
@@ -2,7 +2,13 @@ from rest_framework.views import APIView
 from rest_framework import status, permissions
 from rest_framework.response import Response
 from rest_framework_simplejwt.views import TokenObtainPairView
-from user.serializers import UserSerializer, MyTokenObtainSerializer
+from user.serializers import (
+    UserSerializer,
+    MyTokenObtainSerializer,
+    UserSignOutSerializer,
+)
+from rest_framework.generics import get_object_or_404
+from user.models import User
 
 
 # Create your views here.
@@ -25,6 +31,24 @@ class UserSignUpAndOutView(APIView):
             user_serialized.save()
             return Response(user_serialized.data, status=status.HTTP_201_CREATED)
         return Response(user_serialized.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def put(self, request):
+        """
+        회원탈퇴를 위해 passoword를 입력받아 현재 로그인 중인 유저(request.user)와 비교 후
+        일치하면 해당 유저의 is_active 값을 False로 바꾼다.
+        상태코드 200 : 탈퇴성공
+        상태코드 400 : 비밀번호 틀림
+        """
+        user = request.user
+        user = get_object_or_404(User, id=user.id)
+        serializer = UserSignOutSerializer(user, request.data)
+        if serializer.is_valid():
+            user.is_active = False
+            user.save()
+            return Response(
+                {"message": "signout_success"}, status=status.HTTP_204_NO_CONTENT
+            )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class MyTokenObtaionVeiw(TokenObtainPairView):

--- a/user/views.py
+++ b/user/views.py
@@ -45,9 +45,7 @@ class UserSignUpAndOutView(APIView):
         if serializer.is_valid():
             user.is_active = False
             user.save()
-            return Response(
-                {"message": "signout_success"}, status=status.HTTP_204_NO_CONTENT
-            )
+            return Response({"message": "signout_success"}, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 


### PR DESCRIPTION
탈퇴를 위한 기능 추가가 있습니다.
회원 탈퇴를 위한 view와 serializser를 만들었습니다.
비밀번호 입력 요구후 일치 시 is_active가 False 변경후 저장됩니다.
또한 탈퇴를 위한 커스텀 퍼미션을 만들었습니다. 오직 로그인 된 사용자만 탈퇴 요청을 보낼 수 있읍니다.
회원가입과 탈퇴가 같은 view 클래스를 사용하는데, 현재로서는 회원가입(post)의 경우엔 무조건 처리가능하도록 되어있습니다.