### PR TITLE
Feature/user/user edit

### DIFF
--- a/user/permissions.py
+++ b/user/permissions.py
@@ -3,7 +3,10 @@ from rest_framework import permissions
 
 class SignOutAuthenticatedOnly(permissions.BasePermission):
     def has_permission(self, request, view):
-        if request.method == "PUT":
-            return bool(request.user and request.user.is_authenticated)
-        else:
+        """
+        POST 요청(회원가입)만은 비회원이라도 가능해야하므로 무조건 True
+        이외에는 로그인한 유저 본인의 정보에 대한 것이므로 로그인 여부를 확인한다.
+        """
+        if request.method == "POST":
             return True
+        return bool(request.user and request.user.is_authenticated)

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -7,6 +7,22 @@ PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,32
 USERNAME_REGEX = "^[A-Za-z\d]+[A-Za-z\d_\-@]{5,31}$"
 
 
+def password_validation(password, password2):
+    """
+    비밀번호와 비밀번호 확인 입력을 검증하기 위한 코드입니다.
+    둘의 일치를 먼저 확인하고 입력값 자체가 유효한지 regex를 이용해 확인합니다.
+    """
+    if password != password2:
+        raise serializers.ValidationError({"password": "두 비멀번호가 일치하지 않습니다."})
+
+    if password != None and not re.match(PASSWORD_REGEX, password):
+        raise serializers.ValidationError(
+            {
+                "password": "비밀번호는 8자리~32자리, 한개 이상의 숫자/알파벳/특수문자(@,$,!,%,*,#,?,&)로 이루어져야합니다."
+            }
+        )
+
+
 class UserSerializer(serializers.ModelSerializer):
     """
     유저를 생성하거나 유저정보를 조회하기 위해 쓰이는 serializer이다.
@@ -45,15 +61,7 @@ class UserSerializer(serializers.ModelSerializer):
         passwor와 password2가 일치하는지 확인
         이외 나머지 검증은 부모 클래스의 validate에 맡김
         """
-        if attrs.get("password") != attrs.get("password2"):
-            raise serializers.ValidationError({"password": "두 비멀번호가 일치하지 않습니다."})
-
-        if not re.match(PASSWORD_REGEX, attrs.get("password")):
-            raise serializers.ValidationError(
-                {
-                    "password": "비밀번호는 8자리~32자리, 한개 이상의 숫자/알파벳/특수문자(@,$,!,%,*,#,?,&)로 이루어져야합니다."
-                }
-            )
+        password_validation(attrs.get("password"), attrs.get("password2"))
         if not re.match(USERNAME_REGEX, attrs.get("username")):
             raise serializers.ValidationError(
                 {
@@ -100,3 +108,47 @@ class MyTokenObtainSerializer(TokenObtainPairSerializer):
         token["email"] = user.email
 
         return token
+
+
+class UserEditSerializer(serializers.ModelSerializer):
+    """
+    유저 정보를 수정하기 위한 시리얼라이저입니다.
+    비밀번호 변경을 원할 수 있기 때문에 passoword2 필드가 추가됩니다.
+    보안을 위해 현재 비밀번호를 입력해 확인하는 과정을 검증에 넣습니다.
+    """
+
+    current_password = serializers.CharField(
+        style={"input_type": "password"}, write_only=True
+    )
+    password2 = serializers.CharField(style={"input_type": "password"}, write_only=True)
+
+    class Meta:
+        model = User
+        exclude = (
+            "email",
+            "username",
+        )
+
+    def update(self, instance, validated_data):
+        """
+        오버라이딩 하였습니다.
+        불필요한 데이터를 제거해 오류를 제거한 뒤 비밀번호 부터 지정 하고 저장을 계속합니다.
+        """
+        validated_data.pop("password2", None)
+        validated_data.pop("current_password", None)
+        if validated_data.get("password"):
+            instance.set_password(validated_data["password"])
+            validated_data.pop("password", None)
+        user = super().update(instance, validated_data)
+        return user
+
+    def validate(self, attrs):
+        """
+        입력된 현재 비밀번호의 유효성부터 겸사합니다.
+        """
+        if not self.instance.check_password(attrs.get("current_password")):
+            raise serializers.ValidationError(
+                {"current password": "current password wrong."}
+            )
+        password_validation(attrs.get("password"), attrs.get("password2"))
+        return super().validate(attrs)

--- a/user/tests.py
+++ b/user/tests.py
@@ -7,9 +7,11 @@ from user.models import User
 
 
 # Create your tests here.
+class UserBaseTestCase(APITestCase):
+    """
+    회원가입과 로그인이 필요한 기능들을 위한 부모 클래스입니다.
+    """
 
-
-class UserSignOutTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.user = User.objects.create_user(
@@ -22,7 +24,16 @@ class UserSignOutTestCase(APITestCase):
     def setUp(self) -> None:
         self.access = self.client.post(reverse("token"), self.user_data).data["access"]
 
+
+class UserSignOutTestCase(UserBaseTestCase):
+    """
+    탈퇴기능을 검정하기 위한 케이스
+    """
+
     def test_logined(self):
+        """
+        정상 케이스
+        """
         url = reverse("signup/out")
         response = self.client.put(
             path=url,
@@ -32,6 +43,9 @@ class UserSignOutTestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_annon(self):
+        """
+        비 로그인 회원
+        """
         url = reverse("signup/out")
         response = self.client.put(
             path=url,
@@ -40,6 +54,9 @@ class UserSignOutTestCase(APITestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_password(self):
+        """
+        비밀번호 불일치
+        """
         url = reverse("signup/out")
         response = self.client.put(
             path=url,
@@ -49,10 +66,143 @@ class UserSignOutTestCase(APITestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_wrong_token(self):
+        """
+        토큰 유효하지 않음
+        """
         url = reverse("signup/out")
         response = self.client.put(
             path=url,
             HTTP_AUTHORIZATION=f"Bearer {self.access[:-3]}123",
             data=self.user_data,
+        )
+        self.assertEqual(response.status_code, 401)
+
+
+class UserPATCHTestCase(UserBaseTestCase):
+    """
+    유저정보 수정을 검증하기 위한 클래스
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """
+        부모클래스에서 사용한 user 정보는 탈퇴 검증과정에서 is_activate가 불활성화되므로 새로 지정한다.
+        """
+        cls.user = User.objects.create_user(
+            username="zxcvbnasdf_@",
+            email="abcd@navers.com",
+            password="asdf1234!!",
+        )
+        cls.user_data = {"username": "zxcvbnasdf_@", "password": "asdf1234!!"}
+
+    def setUp(self) -> None:
+        self.access = self.client.post(reverse("token"), self.user_data).data["access"]
+
+    def test_logined(self):
+        """
+        일반적으로 로그인한 유저의 경우
+        """
+
+        # 비밀번호 변경
+        url = reverse("signup/out")
+        data = {
+            "current_password": "asdf1234!!",
+            "password": "asdf1234!!",
+            "password2": "asdf1234!!",
+        }
+        response = self.client.patch(
+            path=url, HTTP_AUTHORIZATION=f"Bearer {self.access}", data=data
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # 아무것도 변경안함
+        data = {
+            "current_password": "asdf1234!!",
+        }
+        response = self.client.patch(
+            path=url, HTTP_AUTHORIZATION=f"Bearer {self.access}", data=data
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # 비밀번호 변경 시도 - 하나만 입력
+        data = {"current_password": "asdf1234!!", "password2": "asdf1234!!"}
+        response = self.client.patch(
+            path=url, HTTP_AUTHORIZATION=f"Bearer {self.access}", data=data
+        )
+        self.assertEqual(response.status_code, 400)
+
+        # 비밀 번호 불일치
+        data = {
+            "current_password": "asdf1234!!",
+            "password": "asdf123!!",
+            "password2": "asdf1234!!",
+        }
+        response = self.client.patch(
+            path=url, HTTP_AUTHORIZATION=f"Bearer {self.access}", data=data
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_annon(self):
+        """
+        비 로그인 익명 사용자가 시도시
+        """
+        url = reverse("signup/out")
+        data = {
+            "current_password": "asdf1234!!",
+            "password": "asdf1234!!",
+            "password2": "asdf1234!!",
+        }
+        response = self.client.patch(path=url, data=data)
+        self.assertEqual(response.status_code, 401)
+
+    def test_wrong_token(self):
+        """
+        유효하지 않은 토큰
+        """
+
+        url = reverse("signup/out")
+        data = {
+            "current_password": "asdf1234!!",
+            "password": "asdf1234!!",
+            "password2": "asdf1234!!",
+        }
+        response = self.client.patch(
+            path=url,
+            data=data,
+            HTTP_AUTHORIZATION=f"Bearer {self.access[:-3]}123",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_wrong_password(self):
+        url = reverse("signup/out")
+        data = {
+            "current_password": "asdf11234!!",
+            "password": "asdf1234!!",
+            "password2": "asdf1234!!",
+        }
+        response = self.client.patch(
+            path=url,
+            data=data,
+            HTTP_AUTHORIZATION=f"Bearer {self.access}",
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+class UserGetTestCase(UserBaseTestCase):
+    def test_get_logined(self):
+        url = reverse("signup/out")
+        response = self.client.get(path=url, HTTP_AUTHORIZATION=f"Bearer {self.access}")
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_annon(self):
+        url = reverse("signup/out")
+        response = self.client.get(path=url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_wrong_token(self):
+        url = reverse("signup/out")
+        response = self.client.put(
+            path=url,
+            HTTP_AUTHORIZATION=f"Bearer {self.access[:-3]}123",
         )
         self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
사용자가 자신의 회원정보를 열람가능합니다.
사용자가 비밀번호를 입력하고 자신의 유저정보(현재는 오직 password만)을 수정할 수 있는 기능이 추가되었습니다.
비밀번호가 올바르지 않을 경우 변경되지 않습니다.
로그인이 필수 입니다.

회원 수정과 회원 정보 조회 기능테스트 코드를 작성하였습니다.
공통적으로 회원가입과 로그인이 필요한 테스트 케이스를 하나의 부모클래스를 가지도록 해 코드중복 감소
2. 정상적인 로그인유저, 비로그인유저, 비밀번호 틀림, 토큰 만료 - 4가지 경우의 수 고려