### PR TITLE
Fix : Remove redundant Code

### DIFF
--- a/user/tests.py
+++ b/user/tests.py
@@ -83,21 +83,6 @@ class UserPATCHTestCase(UserBaseTestCase):
     유저정보 수정을 검증하기 위한 클래스
     """
 
-    @classmethod
-    def setUpTestData(cls) -> None:
-        """
-        부모클래스에서 사용한 user 정보는 탈퇴 검증과정에서 is_activate가 불활성화되므로 새로 지정한다.
-        """
-        cls.user = User.objects.create_user(
-            username="zxcvbnasdf_@",
-            email="abcd@navers.com",
-            password="asdf1234!!",
-        )
-        cls.user_data = {"username": "zxcvbnasdf_@", "password": "asdf1234!!"}
-
-    def setUp(self) -> None:
-        self.access = self.client.post(reverse("token"), self.user_data).data["access"]
-
     def test_logined(self):
         """
         일반적으로 로그인한 유저의 경우


### PR DESCRIPTION
테스트코드를 테스트해본 결과, 기존 오류 방지를 위해 작성했던 코드가 의미없음이 발견
따라서 해당 코드를 삭제했습니다.
회원 탈퇴 테스트와 회원 수정 테스트에서 같은 유저정보를 사용했는데
이로인해 계정 비활성화로 인한 오류가 발생한줄 알았으나
실제로는 수정시 partial 옵션을 주지 않아 전체 정보가 수정되고 이로인해
is_active가 False가 되는 현상으로 인한 오류였습니다.